### PR TITLE
Fix: include library

### DIFF
--- a/GeneralUtility.h
+++ b/GeneralUtility.h
@@ -6,6 +6,9 @@
 #define iprint(name) myprinter(#name, (name))
 #endif
 
+#include "itensor/all.h"
+
+using namespace itensor;
 using namespace std;
 
 template <typename TType>


### PR DESCRIPTION
Hi Chiamin,

I often receive the complains from complier that it can not recognize the data type defined by ITensor, so I just add 2 lines to include ITensor.

I think this should not affect anything on other projects that depend on this repo.

Taolin